### PR TITLE
exit with error when specified target is not found in source deps

### DIFF
--- a/bazel2snyk/cli.py
+++ b/bazel2snyk/cli.py
@@ -284,6 +284,12 @@ def main(
 
     bazel2snyk.bazel_to_depgraph(parent_node_id=bazel_target, depth=0)
 
+    if len(bazel2snyk.dep_graph.graph()["depGraph"]["graph"]["nodes"]) <= 1:
+        logger.error(
+            f"No {package_source} dependencies found for given target, please verify --bazel-target exists in the source data"
+        )
+        sys.exit(2)
+
     if prune_all:
         logger.info("Pruning graph ...")
         time.sleep(2)

--- a/bazel2snyk/test/fixtures/__init__.py
+++ b/bazel2snyk/test/fixtures/__init__.py
@@ -27,6 +27,20 @@ pip_args["bad_args"] = [
     "abcdefg",
 ]
 
+pip_args["bad_target"] = [
+    # "--debug",
+    "--print-deps",
+    "--package-source",
+    "pip",
+    "--bazel-deps-xml",
+    f"{pip_fixtures['pip']}",
+    "--bazel-target",
+    "//snyk/cli:main",
+    "print-graph",
+    "--snyk-org-id",
+    "abcdefg",
+]
+
 pip_args["print_graph"] = [
     # "--debug",
     "--print-deps",

--- a/bazel2snyk/test/test_cli.py
+++ b/bazel2snyk/test/test_cli.py
@@ -14,6 +14,15 @@ def test_bad_args():
     assert result.exit_code == 2
 
 
+def test_bad_target():
+    """
+    Test for target not found in source
+
+    """
+    result = runner.invoke(cli, pip_args["bad_target"])
+    assert result.exit_code == 2
+
+
 def test_pip_command_print_graph():
     """
     Test for printing the dep graph


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written in [README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines

### What this does

if the value specified in `--bazel-target` is not found in the source xml, then the script will exit with error code 2 rather than proceeding to create an empty depgraph.
