### PR TITLE
chore: correct maven tests which were incorrectly specified as pip

### DIFF
--- a/bazel2snyk/test/test_cli.py
+++ b/bazel2snyk/test/test_cli.py
@@ -1,6 +1,7 @@
 from typer.testing import CliRunner
 from bazel2snyk.cli import cli
 from bazel2snyk.test.fixtures import pip_args
+from bazel2snyk.test.fixtures import maven_args
 
 runner = CliRunner()
 
@@ -42,7 +43,7 @@ def test_maven_command_print_graph():
     """
     Test for printing the dep graph
     """
-    result = runner.invoke(cli, pip_args["print_graph"])
+    result = runner.invoke(cli, maven_args["print_graph"])
     assert result.exit_code == 0
 
 
@@ -50,7 +51,7 @@ def test_maven_command_test():
     """
     Test for testing the dep graph
     """
-    result = runner.invoke(cli, pip_args["test"])
+    result = runner.invoke(cli, maven_args["test"])
     assert result.exit_code == 1
 
 
@@ -58,5 +59,5 @@ def test_maven_command_monitor():
     """
     Test for monitoring the dep graph in snyk
     """
-    result = runner.invoke(cli, pip_args["monitor"])
+    result = runner.invoke(cli, maven_args["monitor"])
     assert result.exit_code == 0


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written in [README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines
