### PR TITLE
try 3.10 python support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,14 +5,17 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ["3.9", "3.10"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.9
+      - name: Set up Python ${{ matrix.version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.version }}
 
       - name: Install Poetry
         run: pip install poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Scott Esbrandt <scott.esbrandt@snyk.io>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = "~3.9"
+python =  ">=3.9,<3.11"
 pysnyk = "^0.9.2"
 typer = "^0.4.1"
 pydantic = "^2.6.4"


### PR DESCRIPTION

- [X] Tests written and linted
- [ ] Documentation written in [README](../README.md) -- not need
- [X] Commit history is tidy & follows Contributing guidelines


### What this does

Allows to use the tool with the python 3.10. 

The deeper reason for adding 3.10 Python is to allow adding of this project as a dependency on another poetry project. We do not want to downgrade the Python version. But poetry does not allow to install this project as the specified version is lower.

We checked that test/monitor functions work well with 3.10.
A test matrix also was added to test with both Python 3.9 and 3.10

### Notes for the reviewer

Some tests failed because the fork repo does not have access to the orgs used in tests.